### PR TITLE
Extend the public API

### DIFF
--- a/eros.el
+++ b/eros.el
@@ -1,12 +1,12 @@
 ;;; eros.el --- Evaluation Result OverlayS for Emacs Lisp   -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2016-2018  Tianxiang Xiong
+;; Copyright (C) 2016-2021  Tianxiang Xiong
 
 ;; Author: Tianxiang Xiong <tianxiang.xiong@gmail.com>
 ;; Keywords: convenience, lisp
 ;; Package-Requires: ((emacs "24.4"))
 ;; URL: https://github.com/xiongtx/eros
-;; Version: 0.1.0
+;; Version: 0.2.0
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -212,31 +212,30 @@ This function also removes itself from `pre-command-hook'."
   (remove-hook 'pre-command-hook #'eros--remove-result-overlay 'local)
   (remove-overlays nil nil 'category 'result))
 
-(defun eros--eval-overlay (value point)
-  "Make overlay for VALUE at POINT."
-  (eros--make-result-overlay (format "%S" value)
-    :where point
-    :duration eros-eval-result-duration)
-  value)
 
 
 ;; API
 
+(defun eros-eval-overlay (value point)
+  "Make overlay for VALUE at POINT using FMT as format string."
+  (eros--make-result-overlay value
+    :where point
+    :duration eros-eval-result-duration))
+
 (defun eros-eval-last-sexp (eval-last-sexp-arg-internal)
   "Wrapper for `eval-last-sexp' that overlays results."
   (interactive "P")
-  (eros--eval-overlay
-   (eval-last-sexp eval-last-sexp-arg-internal)
-   (point)))
+  (let ((value (eval-last-sexp eval-last-sexp-arg-internal)))
+    (eros-eval-overlay (format "%S" value) (point))
+    value))
 
 (defun eros-eval-defun (edebug-it)
   "Wrapper for `eval-defun' that overlays results."
   (interactive "P")
-  (eros--eval-overlay
-   (eval-defun edebug-it)
-   (save-excursion
-     (end-of-defun)
-     (point))))
+  (let ((value (eval-defun edebug-it))
+        (point (save-excursion (end-of-defun) (point))))
+    (eros-eval-overlay (format "%S" value) point)
+    value))
 
 
 ;; Minor mode


### PR DESCRIPTION
Expose eros-eval-overlay as a part of the public API for other packages to use.  This function now only creates overlays, evaluation, and result propagation moved to the elisp related functions

As an example, I've used this new public API to make `fennel-mode` functions use overlays:

https://github.com/andreyorst/dotfiles/blob/6ac822fd6c4ae6da3100e8925666b45e8c484e38/.config/emacs/init.el#L541-L589

This works quite well. However, Fennel REPL can't return any kind of values to Emacs, because a) it's not possible in the current implementation of the REPL, so I had to work around it using comint functions b) it is meaningless, emacs can't use Fennel's values anyways, With that, I think it's fair to say that most other languages that support interactive evaluation can't really provide values to Emacs, and thus `eros-eval-overlay` should only draw the overlay itself, which I did in this PR.

Additionally, it's now possible to implement the feature requested in #3. It doesn't matter that region can't return the value, and the fact that it is a string no longer a problem as you can `format` to the needed string representation before creating an overlay (similarly to what I do for Fennel)

I've updated the version to 0.2.0, and copyright year to 2021.