### PR TITLE
Add `eros-inspect-last-result`

### DIFF
--- a/eros.el
+++ b/eros.el
@@ -257,7 +257,9 @@ This function also removes itself from `pre-command-hook'."
   (interactive)
   (when eros--last-result
     (get-buffer-create eros--inspect-buffer-name)
-    (pp-display-expression eros--last-result eros--inspect-buffer-name)
+    (let ((print-length nil)
+          (print-level nil))
+      (pp-display-expression eros--last-result eros--inspect-buffer-name))
     (unless (get-buffer-window eros--inspect-buffer-name)
       (switch-to-buffer-other-window eros--inspect-buffer-name))))
 

--- a/eros.el
+++ b/eros.el
@@ -78,6 +78,16 @@ If the symbol `command', they're erased before the next command."
                  (const :tag "Last indefinitely" nil))
   :package-version '(eros "0.1.0"))
 
+(defcustom eros-inspect-hooks '()
+  "Hooks to run after eros-inspect buffer is opened. Especially
+useful for disabling stuff, like flycheck etc.
+
+    (add-hook 'eros-inspect-hooks (lambda () (flycheck-mode -1)))
+"
+  :group 'eros
+  :type 'hook
+  :package-version '(eros "0.1.0"))
+
 
 ;; Internals
 
@@ -259,7 +269,9 @@ This function also removes itself from `pre-command-hook'."
     (get-buffer-create eros--inspect-buffer-name)
     (let ((print-length nil)
           (print-level nil))
-      (pp-display-expression eros--last-result eros--inspect-buffer-name))
+      (pp-display-expression eros--last-result eros--inspect-buffer-name)
+      (with-current-buffer (get-buffer-create eros--inspect-buffer-name)
+        (run-hooks 'eros-inspect-hooks)))
     (unless (get-buffer-window eros--inspect-buffer-name)
       (switch-to-buffer-other-window eros--inspect-buffer-name))))
 

--- a/eros.el
+++ b/eros.el
@@ -31,6 +31,7 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'pp)
 
 
 ;; Customize
@@ -76,6 +77,15 @@ If the symbol `command', they're erased before the next command."
                  (const :tag "Until next command" command)
                  (const :tag "Last indefinitely" nil))
   :package-version '(eros "0.1.0"))
+
+
+;; Internals
+
+(defvar eros--inspect-buffer-name "*eros inspect*"
+  "Buffer name for showing pretty printed results.")
+
+(defvar eros--last-result nil
+  "Result of the last `eros-eval-*' call.")
 
 
 ;; Overlay
@@ -225,9 +235,13 @@ This function also removes itself from `pre-command-hook'."
 (defun eros-eval-last-sexp (eval-last-sexp-arg-internal)
   "Wrapper for `eval-last-sexp' that overlays results."
   (interactive "P")
-  (eros--eval-overlay
-   (eval-last-sexp eval-last-sexp-arg-internal)
-   (point)))
+  (let ((result (eval-last-sexp eval-last-sexp-arg-internal)))
+    (setq eros--last-result result)
+    (when (get-buffer eros--inspect-buffer-name)
+      (eros-inspect-last-result))
+    (eros--eval-overlay
+     result
+     (point))))
 
 (defun eros-eval-defun (edebug-it)
   "Wrapper for `eval-defun' that overlays results."
@@ -237,6 +251,15 @@ This function also removes itself from `pre-command-hook'."
    (save-excursion
      (end-of-defun)
      (point))))
+
+(defun eros-inspect-last-result ()
+  "Inspect the result of last `eros-eval-'."
+  (interactive)
+  (when eros--last-result
+    (get-buffer-create eros--inspect-buffer-name)
+    (pp-display-expression eros--last-result eros--inspect-buffer-name)
+    (unless (get-buffer-window eros--inspect-buffer-name)
+      (switch-to-buffer-other-window eros--inspect-buffer-name))))
 
 
 ;; Minor mode


### PR DESCRIPTION
A feature I miss from CIDER is that `cider-inspect-last-result`. This
PR provides somewhat similar feature to that. CIDER has it's own very
powerful inspector but here I just used the `pp-display-expression`
function from `pp.el`.

When `eros-inspect-last-result` is called, it shows the result of last
`eros-eval-last-sexp` in a pretty printed format in a different buffer
named `*eros-inspect*`. If the `*eros-inspect*` buffer is already
created, every call to `eros-eval-last-sexp` updates the contents of
the `*eros-inspect*` buffer automatically.

I don't know if you want to include something like this (or even if
you are maintaining the project actively still) but I was going to
implement it for myself and thought I could open a PR.
